### PR TITLE
design(post): post 페이지 헤더 아이콘 레이아웃 정리 및 스타일 반영

### DIFF
--- a/src/features/post/pages/CommentsPage.tsx
+++ b/src/features/post/pages/CommentsPage.tsx
@@ -28,6 +28,8 @@ export default function CommentsPage() {
 
   useEffect(() => {
     if (!postId) return
+
+    setLoading(true)
     getComments(postId)
       .then(({ comment }) => setComments(comment))
       .catch(console.error)
@@ -36,6 +38,7 @@ export default function CommentsPage() {
 
   const handleSubmit = async () => {
     if (!postId || !content.trim() || submitting) return
+
     setSubmitting(true)
     try {
       const { comment } = await createComment(postId, content.trim())
@@ -50,74 +53,115 @@ export default function CommentsPage() {
 
   const handleDelete = async () => {
     if (!postId || !selectedComment) return
+
     try {
       await deleteComment(postId, selectedComment.id)
       setComments((prev) => prev.filter((c) => c.id !== selectedComment.id))
     } catch (err) {
       console.error(err)
     }
+
     setSelectedComment(null)
     setShowDeleteModal(false)
+    setShowSheet(false)
   }
 
   const handleReport = async () => {
     if (!postId || !selectedComment) return
+
     try {
       await reportComment(postId, selectedComment.id)
     } catch (err) {
       console.error(err)
     }
+
     setShowReportModal(false)
+    setShowSheet(false)
   }
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <TopBar title="댓글" showBack />
+    <div className="flex min-h-screen flex-col bg-[#F5F5F5]">
+      {/* Top Bar - 피그마 스타일(뒤로가기 + 세로 더보기) */}
+    <TopBar
+  title=""
+  showBack
+  rightSlot={
+    <button
+      type="button"
+      className="flex h-8 w-8 items-center justify-center"
+      aria-label="게시글 옵션"
+    >
+      <img
+        src="/icons/icon-more-vertical.svg"
+        alt=""
+        className="h-5 w-5 object-contain"
+      />
+    </button>
+  }
+/>
 
       {/* Comments list */}
       <div className="flex-1 px-4 py-3 pb-24">
         {loading ? (
-          <div className="flex justify-center py-10"><Spinner /></div>
+          <div className="flex justify-center py-10">
+            <Spinner />
+          </div>
         ) : comments.length === 0 ? (
-          <p className="text-center text-sm text-gray-400 py-10">첫 댓글을 작성해보세요!</p>
+          <p className="py-10 text-center text-sm text-gray-400">
+            첫 댓글을 작성해보세요!
+          </p>
         ) : (
           comments.map((comment) => (
-            <div key={comment.id} className="flex gap-2 mb-4">
-              <Avatar src={comment.author.image} alt={comment.author.username} size="xs" />
-              <div className="flex-1">
-                <div className="flex items-baseline gap-1.5 mb-0.5">
-                  <span className="text-xs font-semibold text-gray-900">
-                    {comment.author.username}
-                  </span>
-                  <span className="text-xs text-gray-400">
-                    {formatRelativeTime(comment.createdAt)}
-                  </span>
+            <div key={comment.id} className="mb-5 flex gap-3">
+              <Avatar
+                src={comment.author.image}
+                alt={comment.author.username}
+                size="xs"
+              />
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1 flex items-baseline gap-1.5">
+                      <span className="truncate text-[14px] font-semibold text-gray-900">
+                        {comment.author.username}
+                      </span>
+                      <span className="shrink-0 text-[12px] text-gray-400">
+                        · {formatRelativeTime(comment.createdAt)}
+                      </span>
+                    </div>
+
+                    <p className="break-words text-[14px] leading-6 text-gray-700">
+                      {comment.content}
+                    </p>
+                  </div>
+
+                  <button
+                    onClick={() => {
+                      setSelectedComment(comment)
+                      setShowSheet(true)
+                    }}
+                    className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center"
+                    aria-label="댓글 옵션"
+                    type="button"
+                  >
+                    <img
+                      src="/icons/icon-more-vertical.svg"
+                      alt=""
+                      className="h-5 w-5 object-contain opacity-80"
+                    />
+                  </button>
                 </div>
-                <p className="text-sm text-gray-700 leading-relaxed">{comment.content}</p>
               </div>
-         <button
-  onClick={() => {
-    setSelectedComment(comment)
-    setShowSheet(true)
-  }}
-  className="self-start flex h-6 w-6 items-center justify-center"
-  aria-label="댓글 옵션"
-  type="button"
->
-  <img
-    src="/icons/icon-more-vertical.svg"
-    alt=""
-     className="h-6 w-6 object-contain"
-  />
-</button>
             </div>
           ))
         )}
       </div>
 
       {/* Input area */}
-      <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-mobile bg-white border-t border-gray-100 px-4 py-3 flex items-center gap-2">
+      <div className="fixed bottom-0 left-1/2 z-20 flex w-full max-w-mobile -translate-x-1/2 items-center gap-2 border-t border-[#EAEAEA] bg-white px-4 py-3">
         <Avatar src={me?.image} alt={me?.username} size="xs" />
+
         <input
           ref={inputRef}
           type="text"
@@ -130,12 +174,13 @@ export default function CommentsPage() {
               handleSubmit()
             }
           }}
-          className="flex-1 text-sm outline-none bg-transparent placeholder:text-gray-400"
+          className="flex-1 bg-transparent text-[14px] outline-none placeholder:text-gray-300"
         />
+
         <button
           onClick={handleSubmit}
           disabled={!content.trim() || submitting}
-          className="text-sm font-semibold text-brand disabled:text-gray-300"
+          className="px-1 text-[14px] font-semibold text-[#C7C7C7] disabled:text-[#D9D9D9]"
         >
           게시
         </button>
@@ -151,14 +196,20 @@ export default function CommentsPage() {
                 {
                   label: '삭제',
                   danger: true,
-                  onClick: () => setShowDeleteModal(true),
+                  onClick: () => {
+                    setShowSheet(false)
+                    setShowDeleteModal(true)
+                  },
                 },
               ]
             : [
                 {
                   label: '신고',
                   danger: true,
-                  onClick: () => setShowReportModal(true),
+                  onClick: () => {
+                    setShowSheet(false)
+                    setShowReportModal(true)
+                  },
                 },
               ]
         }

--- a/src/features/post/pages/PostDetailPage.tsx
+++ b/src/features/post/pages/PostDetailPage.tsx
@@ -84,21 +84,22 @@ export default function PostDetailPage() {
   return (
     <div className="flex flex-col">
 <TopBar
+  title=""
   showBack
-rightSlot={
-  <button
-    onClick={() => setShowPostSheet(true)}
-    className="flex h-8 w-8 items-center justify-center"
-    aria-label="더보기"
-    type="button"
-  >
-    <img
-      src="/icons/icon-more-vertical.svg"
-      alt=""
-      className="h-6 w-6 object-contain"
-    />
-  </button>
-}
+  rightSlot={
+    <button
+      onClick={() => setShowPostSheet(true)}
+      className="flex h-8 w-8 items-center justify-center"
+      aria-label="더보기"
+      type="button"
+    >
+      <img
+        src="/icons/icon-more-vertical.svg"
+        alt=""
+        className="h-6 w-6 object-contain"
+      />
+    </button>
+  }
 />
 
       <article className="px-4 py-4">


### PR DESCRIPTION
변경 내용
Post 관련 페이지의 상단 헤더 UI를 피그마 기준에 맞게 정리했습니다.
좌측 뒤로가기 / 우측 더보기 아이콘은 유지하고, 가운데 영역은 비워진 상태로 보이도록 레이아웃을 조정했습니다.
Post 페이지 내 더보기(세로 점) 아이콘 스타일/크기/정렬을 화면 기준에 맞게 수정했습니다.

수정 파일
src/features/post/pages/CommentsPage.tsx
src/features/post/pages/PostDetailPage.tsx

확인 포인트
상단 헤더에서 좌/우 아이콘이 정상 표시되는지
가운데 타이틀 영역이 비어 보이도록 정렬되는지
댓글/게시글 상세에서 더보기 아이콘 위치와 크기가 일관적인지
기존 기능(댓글 작성, 신고/삭제, 바텀시트) 동작에 영향 없는지
