### PR TITLE
design(chat): chat 헤더 및 TopBar 아이콘 레이아웃 스타일 수정

### DIFF
--- a/src/app/layouts/TopBar.tsx
+++ b/src/app/layouts/TopBar.tsx
@@ -23,26 +23,37 @@ export default function TopBar({
         transparent ? 'bg-transparent' : 'bg-white border-b border-gray-200',
       ].join(' ')}
     >
-      {showBack && (
-        <button
-  type="button"
-  onClick={() => navigate(-1)}
-  className="flex h-10 w-10 items-center justify-center"
-  aria-label="뒤로가기"
->
-  <img
-    src="/icons/icon-arrow-left.svg"
-    alt=""
-    className="h-6 w-6 object-contain"
-  />
-</button>
-      )}
+      {/* 왼쪽 */}
+      <div className="flex w-10 items-center justify-start">
+        {showBack && (
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="flex h-10 w-10 items-center justify-center -ml-2"
+            aria-label="뒤로가기"
+          >
+            <img
+              src="/icons/icon-arrow-left.svg"
+              alt=""
+              className="h-6 w-6 object-contain"
+            />
+          </button>
+        )}
+      </div>
 
-      <h1 className="flex-1 text-base font-semibold text-gray-900 truncate">
-        {title}
-      </h1>
+      {/* 가운데 (제목 없으면 비워둠) */}
+      <div className="flex-1 text-center">
+        {title ? (
+          <h1 className="truncate text-base font-semibold text-gray-900">
+            {title}
+          </h1>
+        ) : null}
+      </div>
 
-     {rightSlot && <div>{rightSlot}</div>}
+      {/* 오른쪽 */}
+      <div className="flex w-10 items-center justify-end">
+        {rightSlot}
+      </div>
     </header>
   )
 }

--- a/src/features/chat/pages/ChatRoomPage.tsx
+++ b/src/features/chat/pages/ChatRoomPage.tsx
@@ -53,32 +53,35 @@ export default function ChatRoomPage() {
   return (
     <div className="flex flex-col min-h-screen">
      {/* TopBar */}
-<header className="sticky top-0 z-30 flex items-center h-14 px-4 bg-white border-b border-gray-100">
+<header className="sticky top-0 z-30 flex h-14 items-center border-b border-gray-100 bg-white px-4">
+  {/* 왼쪽 뒤로가기 */}
   <button
     type="button"
     onClick={() => navigate(-1)}
-    className="flex h-10 w-10 items-center justify-center -ml-1 mr-2"
+    className="flex h-8 w-8 items-center justify-center"
     aria-label="뒤로가기"
   >
     <img
       src="/icons/icon-arrow-left.svg"
       alt=""
-      className="h-6 w-6 object-contain"
+      className="h-5 w-5 object-contain"
     />
   </button>
 
-  <h1 className="flex-1 text-base font-semibold truncate">{chatName}</h1>
+  {/* 가운데 비우기 */}
+  <div className="flex-1" />
 
+  {/* 오른쪽 더보기 */}
   <button
     type="button"
     onClick={() => setShowSheet(true)}
-    className="flex h-10 w-10 items-center justify-center"
-    aria-label="더보기"
+    className="flex h-8 w-8 items-center justify-center"
+    aria-label="채팅방 옵션"
   >
     <img
       src="/icons/icon-more-vertical.svg"
       alt=""
-       className="h-6 w-6 object-contain"
+      className="h-5 w-5 object-contain"
     />
   </button>
 </header>


### PR DESCRIPTION
변경 내용
Chat 화면 상단 헤더 아이콘 레이아웃을 피그마 기준에 맞게 조정했습니다.
공통 TopBar 컴포넌트의 아이콘 정렬/간격을 수정하여 채팅 화면에서 헤더 UI가 자연스럽게 보이도록 반영했습니다.
세로 더보기 아이콘의 크기/배치를 개선했습니다.

수정 파일
src/app/layouts/TopBar.tsx
src/features/chat/pages/ChatRoomPage.tsx

확인 포인트
채팅방 상단 헤더에서 뒤로가기/더보기 아이콘 정렬이 정상인지
TopBar를 사용하는 다른 화면에서 레이아웃 깨짐이 없는지
아이콘 크기/간격이 피그마 시안과 유사한지

참고
공통 컴포넌트(TopBar) 수정이 포함되어 있어, 같은 파일 작업 중인 브랜치와는 머지 시 충돌 가능성이 있습니다.
Post 화면 관련 헤더 수정은 별도 PR(features/post)로 분리했습니다.