### PR TITLE
[style] 로그인 및 회원가입 UI 수치 정밀 조정 (#37)

### DIFF
--- a/src/features/join/pages/JoinEmailPage.tsx
+++ b/src/features/join/pages/JoinEmailPage.tsx
@@ -54,7 +54,7 @@ export default function JoinEmailPage() {
 
   return (
     <div className="flex flex-col min-h-screen">
-      <TopBar title="이메일로 회원가입" showBack />
+      <TopBar title="" showBack />
 
       <div className="flex flex-col flex-1 px-6 pt-10 gap-6">
         <h2 className="text-2xl font-bold text-center text-gray-900 mb-2">

--- a/src/features/login/pages/EmailLoginPage.tsx
+++ b/src/features/login/pages/EmailLoginPage.tsx
@@ -74,7 +74,7 @@ export default function EmailLoginPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-white">
-      <TopBar title="로그인" showBack />
+      <TopBar title="" showBack />
 
       <form onSubmit={handleSubmit} className="flex flex-col flex-1 px-6 pt-10" noValidate>
         <h2 className="text-2xl font-bold text-center text-gray-900 mb-10">로그인</h2>
@@ -94,7 +94,7 @@ export default function EmailLoginPage() {
             />
             {/* [핵심] 이메일 입력창 바로 밑 에러 표시 */}
             {emailError && (
-              <p className="text-xs text-[#EB5757] mt-1">*{emailError}</p>
+              <p className="text-[12px] leading-[14px] text-[#EB5757] mt-1">*{emailError}</p>
             )}
           </div>
 
@@ -112,9 +112,9 @@ export default function EmailLoginPage() {
         </div>
 
         {/* 로그인 결과(비번 틀림 등) 에러 표시 영역 */}
-        <div className="h-6 mt-2">
+        <div className="mt-2">
           {loginError && (
-            <p className="text-xs text-[#EB5757] text-left">*{loginError}</p>
+            <p className="text-[12px] leading-[14px] text-[#EB5757] text-left">*{loginError}</p>
           )}
         </div>
 
@@ -124,7 +124,7 @@ export default function EmailLoginPage() {
           size="lg"
           disabled={!isFormFilled || loading || !!emailError || !!loginError} 
           loading={loading}
-          className="mt-4 text-sm"
+          className="mt-[30px] text-sm"
         >
           {loading ? '처리 중...' : '로그인'}
         </Button>

--- a/src/features/login/pages/LoginMainPage.tsx
+++ b/src/features/login/pages/LoginMainPage.tsx
@@ -6,19 +6,19 @@ const SOCIAL_PROVIDERS = [
   {
     id: 'kakao',
     name: '카카오톡',
-    borderColor: 'border-[#FEE500]',
+    borderColor: 'border-[#F2C94C]',
     icon: <img src="/icons/Vector-1.svg" alt="카카오톡" className="w-6 h-6 object-contain" />,
   },
   {
     id: 'google',
     name: '구글',
-    borderColor: 'border-gray-300',
+    borderColor: 'border-[#767676]',
     icon: <img src="/icons/Group.svg" alt="구글" className="w-6 h-6 object-contain" />,
   },
   {
     id: 'facebook',
     name: '페이스북',
-    borderColor: 'border-[#1877F2]',
+    borderColor: 'border-[#2D9CDB]',
     icon: <img src="/icons/Vector.svg" alt="페이스북" className="w-6 h-6 object-contain" />,
   },
 ]
@@ -28,7 +28,6 @@ export default function LoginMainPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-brand">
-      {/* 상단: 주황색 배경 및 로고 영역 */}
       <div className="flex-1 flex items-center justify-center">
         <img 
           src="/icons/symbol-logo-W.svg" 
@@ -37,22 +36,20 @@ export default function LoginMainPage() {
         />
       </div>
 
-      {/* 하단: 흰색 박스 (피그마 간격 반영) */}
       <div className="bg-white rounded-t-3xl px-[34px] pt-[50px] pb-[82px] flex flex-col">
-        
-        {/* 버튼들 사이 간격 10px 반영 */}
         <div className="flex flex-col gap-[10px]">
           {SOCIAL_PROVIDERS.map((provider) => (
             <Button
               key={provider.id}
               variant="ghost"
               fullWidth
-              // h-[44px]와 font-normal(Regular 400), text-sm(14px) 반영
-              className={`relative h-[44px] border ${provider.borderColor} font-normal text-sm !text-[#767676]`}
+              // h-auto로 설정하고 py-[13px]을 주어 위아래 간격 13px을 맞춤
+              // border 색상은 질문하신 피그마 색상값 적용
+              className={`relative h-auto py-[13px] border ${provider.borderColor} font-normal text-sm !text-[#767676] rounded-[44px]`}
               onClick={() => console.log(`${provider.id} login`)}
             >
-              {/* 아이콘 위치: 좌측 여백 반영 */}
-              <span className="absolute left-[14px] top-1/2 -translate-y-1/2">
+              {/* 아이콘 위치: 좌측 여백 14px 반영 */}
+              <span className="absolute left-[14px] top-1/2 -translate-y-1/2 flex items-center justify-center">
                 {provider.icon}
               </span>
               <span>{provider.name} 계정으로 로그인</span>
@@ -60,7 +57,6 @@ export default function LoginMainPage() {
           ))}
         </div>
 
-        {/* 하단 링크 영역: 버튼 박스 하단으로부터 20px 여백 및 글자 12px 반영 */}
         <div className="flex items-center justify-center gap-3 mt-[20px] text-[12px] font-normal text-[#767676]">
           <button
             onClick={() => navigate(ROUTES.LOGIN_EMAIL)}

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -18,7 +18,7 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const base =
-    'inline-flex items-center justify-center font-semibold rounded-full transition-all duration-150 focus:outline-none disabled:cursor-not-allowed'
+    'inline-flex items-center justify-center font-medium rounded-full transition-all duration-150 focus:outline-none disabled:cursor-not-allowed'
 
   const variants = {
     primary:
@@ -32,7 +32,7 @@ export default function Button({
   const sizes = {
     sm: 'px-4 py-1.5 text-sm',
     md: 'px-6 py-2.5 text-sm',
-    lg: 'px-8 py-3 text-base',
+    lg: 'h-[44px] py-[13px] px-8 text-[14px]',
   }
 
   return (

--- a/src/shared/components/Input.tsx
+++ b/src/shared/components/Input.tsx
@@ -10,9 +10,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, error, underline = false, className = '', ...props }, ref) => {
     if (underline) {
       return (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col ">
           {label && (
-            <label className="text-xs text-gray-500">{label}</label>
+            <label className="text-[12px] text-[#767676] leading-[14px] mb-[10px]">{label}</label>
           )}
           <input
             ref={ref}
@@ -32,9 +32,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     }
 
     return (
-      <div className="flex flex-col gap-1">
+      <div className="flex flex-col ">
         {label && (
-          <label className="text-xs text-gray-500">{label}</label>
+          <label className="text-[12px] text-[#767676] leading-[14px] mb-[10px]">{label}</label>
         )}
         <input
           ref={ref}


### PR DESCRIPTION
###  작업 요약
피그마 시안의 표준 규격(322x44, 간격 10px/13px 등)을 공통 컴포넌트 및 페이지에 반영하여 UI 완성도를 높였습니다.

###  변경 사항(핵심 3줄)
- **Input.tsx**: 라벨 색상(#767676) 반영 및 라벨-입력창 사이 간격(10px)을 위한 스타일 수정
- **Button.tsx**: `lg` 사이즈의 높이(44px), 상하 여백(13px), 글자 크기(14px) 및 두께(Medium) 정밀 조정
- **TopBar**: 이메일 로그인 및 회원가입 페이지 상단바의 제목을 제거하고 뒤로가기 버튼 레이아웃 유지

###  테스트 방법(재현/검증 절차)
1. `npm run dev` 실행 후 로그인 페이지(`ROUTES.LOGIN`) 접속
2. 피그마 시안과 실제 렌더링된 요소의 여백(Margin/Padding) 대조 확인
3. 회원가입 페이지(`ROUTES.JOIN`)의 상단바 타이틀 제거 여부 확인

###  관련 이슈
Closes #37