### PR TITLE
style(search): 검색바 및 뒤로가기 아이콘 디자인 수치 보정(#2)

### DIFF
--- a/src/features/search/pages/SearchPage.tsx
+++ b/src/features/search/pages/SearchPage.tsx
@@ -42,19 +42,18 @@ export default function SearchPage() {
 
   return (
     <div className="flex flex-col min-h-screen bg-white max-w-[390px] mx-auto">
-      {/* 1. 상단 헤더: 우리가 만든 디자인으로 교체 (뒤로가기 추가) */}
-      <header className="sticky top-0 z-30 bg-white border-b border-[#DBDBDB] px-[16px] h-[48px] flex items-center gap-[8px]">
+      <header className="sticky top-0 z-30 bg-white border-b border-[#DBDBDB] px-[16px] h-[48px] flex items-center gap-[20px]">
         <button onClick={() => navigate(-1)} className="p-0 flex-shrink-0">
-          <img src="/icons/icon-arrow-left.svg" alt="뒤로가기" className="w-[24px] h-[24px]" />
+          <img src="/icons/icon-arrow-left.svg" alt="뒤로가기" className="w-[22px] h-[22px]" />
         </button>
-        <div className="flex-1">
+        <div className="flex-1 h-[32px]">
           <input
             type="text"
             placeholder="계정 검색"
             value={keyword}
             onChange={(e) => setKeyword(e.target.value)}
             autoFocus
-            className="w-full bg-[#F2F2F2] px-[16px] py-[7px] rounded-full text-[14px] outline-none placeholder:text-[#C4C4C4]"
+            className="w-full h-full bg-[#F2F2F2] px-[16px] py-0 rounded-full text-[14px] outline-none placeholder:text-[#C4C4C4]"
           />
         </div>
       </header>


### PR DESCRIPTION
작업 요약:
피그마 디자인 가이드와 실제 구현된 검색 페이지 헤더의 수치 불일치 문제를 해결.

변경 사항(핵심 3줄):

검색창 높이 고정: input의 기본 line-height로 인해 37px로 렌더링되던 문제를 h-[32px], py-0 설정을 통해 32px로 고정했습니다.

간격 조정: 헤더 내부의 아이콘과 검색바 사이 gap을 10px에서 20px로 업데이트했습니다.

아이콘 크기 정규화: 뒤로가기 버튼의 크기를 22x22px로 명확히 지정.

테스트 방법(재현/검증 절차):

close #2 