### PR TITLE
[refactor] 로그인/회원가입/프로필 설정 페이지 UI 레이아웃 교정 (#56)

### DIFF
--- a/src/features/join/pages/JoinEmailPage.tsx
+++ b/src/features/join/pages/JoinEmailPage.tsx
@@ -56,8 +56,8 @@ export default function JoinEmailPage() {
     <div className="flex flex-col min-h-screen">
       <TopBar title="" showBack />
 
-      <div className="flex flex-col flex-1 px-6 pt-10 gap-6">
-        <h2 className="text-2xl font-bold text-center text-gray-900 mb-2">
+      <div className="flex flex-col flex-1 px-6 pt-10 ">
+        <h2 className="text-[24px] font-medium leading-[100%] text-center text-[#000000] mb-[40px]">
           이메일로 회원가입
         </h2>
 
@@ -75,7 +75,7 @@ export default function JoinEmailPage() {
           autoComplete="email"
           underline
         />
-
+      <div className="mt-4">
         <Input
           label="비밀번호"
           type="password"
@@ -90,13 +90,13 @@ export default function JoinEmailPage() {
           autoComplete="new-password"
           underline
         />
-
+      </div>
         <Button
           fullWidth
           size="lg"
           disabled={!isValid}
           onClick={handleNext}
-          className="mt-2"
+          className="mt-[30px]"
         >
           다음
         </Button>

--- a/src/features/join/pages/JoinProfilePage.tsx
+++ b/src/features/join/pages/JoinProfilePage.tsx
@@ -109,11 +109,11 @@ export default function JoinProfilePage() {
     <div className="flex flex-col min-h-screen">
       <TopBar showBack />
 
-      <div className="flex flex-col items-center px-6 pt-8 gap-6">
-        <h2 className="text-2xl font-bold text-center text-black">
+      <div className="flex flex-col items-center px-6 pt-8 ">
+        <h2 className="text-[24px] font-medium leading-[100%] text-center text-[#000000]">
           프로필 설정
         </h2>
-        <p className="text-sm text-gray-500 text-center">
+        <p className="text-[14px] text-[#767676] text-center mt-[12px]">
           나중에 언제든지 변경할 수 있습니다.
         </p>
 
@@ -121,7 +121,7 @@ export default function JoinProfilePage() {
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="relative"
+          className="relative mt-[30px]"
         >
           <img
             src={imagePreview}
@@ -140,7 +140,7 @@ export default function JoinProfilePage() {
           />
         </button>
 
-        <div className="w-full flex flex-col gap-5">
+        <div className="w-full flex flex-col mt-[30px]">
           <Input
             label="사용자 이름"
             placeholder="2~10자 이내여야 합니다."
@@ -153,7 +153,7 @@ export default function JoinProfilePage() {
             error={usernameError}
             underline
           />
-
+        <div className="mt-4">
           <Input
             label="계정 ID"
             placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
@@ -166,7 +166,8 @@ export default function JoinProfilePage() {
             error={accountnameError}
             underline
           />
-
+          </div>
+        <div className="mt-4">
           <Input
             label="소개"
             placeholder="자신과 판매할 상품에 대해 소개해 주세요!"
@@ -175,14 +176,14 @@ export default function JoinProfilePage() {
             underline
           />
         </div>
-
+        </div>
         <Button
           fullWidth
           size="lg"
           disabled={!isValid}
           loading={loading}
           onClick={handleSubmit}
-          className="mt-2"
+          className="mt-[30px]"
         >
           감귤마켓 시작하기
         </Button>

--- a/src/features/login/pages/EmailLoginPage.tsx
+++ b/src/features/login/pages/EmailLoginPage.tsx
@@ -77,9 +77,11 @@ export default function EmailLoginPage() {
       <TopBar title="" showBack />
 
       <form onSubmit={handleSubmit} className="flex flex-col flex-1 px-6 pt-10" noValidate>
-        <h2 className="text-2xl font-bold text-center text-gray-900 mb-10">로그인</h2>
+        <h2 className="text-[24px] font-medium leading-[100%] text-center text-[#000000] mb-[40px]">
+  로그인
+</h2>
 
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col ">
           <div>
             <Input
               label="이메일"
@@ -94,10 +96,10 @@ export default function EmailLoginPage() {
             />
             {/* [핵심] 이메일 입력창 바로 밑 에러 표시 */}
             {emailError && (
-              <p className="text-[12px] leading-[14px] text-[#EB5757] mt-1">*{emailError}</p>
+              <p className="text-[12px] leading-[14px] text-[#EB5757] mt-[6px]">*{emailError}</p>
             )}
           </div>
-
+          <div className="mt-4">
           <Input
             label="비밀번호"
             type="password"
@@ -109,14 +111,17 @@ export default function EmailLoginPage() {
             }}
             underline
           />
+         </div> 
         </div>
 
         {/* 로그인 결과(비번 틀림 등) 에러 표시 영역 */}
-        <div className="mt-2">
-          {loginError && (
-            <p className="text-[12px] leading-[14px] text-[#EB5757] text-left">*{loginError}</p>
-          )}
-        </div>
+        {loginError && (
+  <div className="mt-[6px]">
+    <p className="text-[12px] leading-[14px] text-[#EB5757] text-left">
+      *{loginError}
+    </p>
+  </div>
+)}
 
         <Button
           type="submit"

--- a/src/shared/components/Input.tsx
+++ b/src/shared/components/Input.tsx
@@ -26,7 +26,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               .join(' ')}
             {...props}
           />
-          {error && <p className="text-xs text-red-500 mt-0.5">{error}</p>}
+          {error && (
+          <p className="text-[12px] leading-[14px] text-[#EB5757] mt-[6px]">
+            *{error}
+          </p>
+        )}
         </div>
       )
     }
@@ -48,7 +52,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             .join(' ')}
           {...props}
         />
-        {error && <p className="text-xs text-red-500 mt-0.5">{error}</p>}
+        {error && (
+  <p className="text-[12px] leading-[14px] text-[#EB5757] mt-[6px]">
+    *{error}
+  </p>
+)}
       </div>
     )
   },


### PR DESCRIPTION
### 📝 작업 요약
인증 및 프로필 설정 페이지의 요소 간 간격과 타이포그래피를 피그마 시안 수치에 맞춰 재구성했습니다.

### 🚀 변경 사항 (핵심 3줄)
* **제목 폰트 교정**: 제목 폰트를 **24px, Medium, Leading 100%**로 통일하여 시안과 일치시킴
* **조건부 간격 반영**: 입력창 사이 **16px**, 에러 메시지 발생 시 **6px**의 조건부 간격 로직을 `Input` 컴포넌트에 반영
* **레이아웃 최적화**: 소개창과 하단 버튼 사이의 간격을 **30px**로 조정하여 레이아웃 균형 확보

### ✅ 테스트 방법 (재현/검증 절차)
* 각 페이지별 폰트 스타일 및 요소 간 간격 수치 검증
* 에러 메시지 노출 시 하단 요소와의 거리 유지 여부 확인

### 🔗 관련 이슈
Closes #56