### PR TITLE
[fix] 프로필 설정 네트워크 에러 처리 및 상태 초기화 (#79)

### DIFF
--- a/src/features/join/pages/JoinProfilePage.tsx
+++ b/src/features/join/pages/JoinProfilePage.tsx
@@ -171,7 +171,7 @@ export default function JoinProfilePage() {
             }
           }
 
-          setImageError(message) // 위에서 결정된 메시지를 세팅
+          setImageError(message) 
           setLoading(false)
           return
         }


### PR DESCRIPTION
##  작업 요약
프로필 설정 페이지에서 네트워크 연결이 끊겼을 때 발생하는 영문 에러(`Failed to fetch`)를 처리하고, 폼 제출 시 이전 에러 메시지가 남아있는 현상을 수정했습니다.

##  변경 사항 (핵심 3줄)
- **네트워크 에러 한글화**: `isNetworkError` 체크 로직을 통해 "네트워크 연결을 확인해주세요."라는 사용자 친화적인 메시지를 출력합니다.
- **에러 상태 초기화**: `handleSubmit` 시작 시 모든 에러 상태를 `''`로 초기화하여 이전 메시지 잔상을 제거했습니다.
- **예외 처리 강화**: 계정 ID 중복 확인(`Blur`) 및 이미지 업로드 단계에서도 인터넷 끊김을 감지하도록 보강했습니다.

##  테스트 방법 (재현/검증 절차)
1. **아이디 중복 확인 테스트**: 와이파이 해제 후 계정 ID 입력창에서 포커스를 아웃(Blur)했을 때 "네트워크 연결을 확인해주세요."가 뜨는지 확인.
2. **이미지 업로드 테스트**: 사진 선택 후 와이파이 해제 상태에서 '시작하기' 버튼 클릭 시 이미지 관련 에러 확인.
3. **상태 초기화 테스트**: 의도적으로 중복 ID 에러를 낸 뒤, 내용을 수정하고 제출했을 때 이전 빨간색 에러 문구가 사라지는지 확인.

##  관련 이슈
Closes #79