### PR TITLE
fix: 게시물 상세 본문 줄바꿈 처리 및 이미지 로딩 실패 시 플레이스홀더 적용

### DIFF
--- a/src/features/post/pages/PostDetailPage.tsx
+++ b/src/features/post/pages/PostDetailPage.tsx
@@ -211,7 +211,7 @@ export default function PostDetailPage() {
               </div>
 
               {/* 본문 */}
-              <p className="mt-3 text-sm text-gray-800 leading-relaxed whitespace-pre-line">
+              <p className="mt-3 text-sm text-gray-800 leading-relaxed whitespace-pre-line break-words">
                 {post.content}
               </p>
 

--- a/src/shared/components/ImageCarousel.tsx
+++ b/src/shared/components/ImageCarousel.tsx
@@ -20,6 +20,15 @@ export default function ImageCarousel({
 }: Props) {
   const scrollerRef = useRef<HTMLDivElement>(null)
   const [active, setActive] = useState(0)
+  const [brokenImages, setBrokenImages] = useState<Set<number>>(new Set())
+
+  const handleImageError = (idx: number) => {
+    setBrokenImages((prev) => {
+      const next = new Set(prev)
+      next.add(idx)
+      return next
+    })
+  }
 
   const count = images.length
   const canSlide = count > 1
@@ -113,14 +122,21 @@ export default function ImageCarousel({
               key={`${src}-${idx}`}
               className="relative h-full w-full flex-none snap-center"
             >
-            <img
-  src={src}
-  alt=""
-  className="h-full w-full object-cover"
-  loading="lazy"
-  decoding="async"
-  draggable={false}
-/>
+            {brokenImages.has(idx) ? (
+                <div className="h-full w-full bg-gray-100 flex items-center justify-center">
+                  <span className="text-xs text-gray-400">이미지를 불러올 수 없습니다</span>
+                </div>
+              ) : (
+                <img
+                  src={src}
+                  alt=""
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                  decoding="async"
+                  draggable={false}
+                  onError={() => handleImageError(idx)}
+                />
+              )}
 
               {onRemove && (
                 <button


### PR DESCRIPTION
#️⃣연관된 이슈
close: #95

🪄작업 내용
게시물 상세 페이지에서 긴 텍스트(URL 등) 입력 시 레이아웃이 무너지는 현상과 이미지 로딩 실패 시의 예외 처리를 완료했습니다.

1. 본문 텍스트 줄바꿈 처리 (PostDetailPage)
현상: 게시물 본문에 공백이 없는 긴 URL이나 텍스트가 포함될 경우, whitespace-pre-line만으로는 줄바꿈이 되지 않아 레이아웃 규격을 벗어나는 버그가 있었습니다.

해결: 본문 <p> 태그에 break-words 클래스를 추가하여 컨테이너 너비를 넘지 않고 안전하게 줄바꿈되도록 수정했습니다.

2. 이미지 로딩 실패 시 플레이스홀더 적용 (ImageCarousel)
현상: 잘못된 이미지 URL이나 지원하지 않는 파일 형식인 경우, 브라우저 기본 '깨진 이미지' 아이콘이 노출되어 UI가 지저분해 보이는 문제가 있었습니다.

해결: onError 이벤트를 활용해 로딩에 실패한 이미지를 감지하고, 해당 영역을 **"이미지를 불러올 수 없습니다"**라는 안내 문구가 포함된 회색 플레이스홀더 UI로 대체 렌더링하도록 개선했습니다.