### PR TITLE
fix(shared): 게시글 이미지 필터링 및 캐러셀 정렬 오류 통합 수정 #2

### DIFF
--- a/src/shared/components/ImageCarousel.tsx
+++ b/src/shared/components/ImageCarousel.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function ImageCarousel({
   images,
   className = '',
-  aspectClassName = 'aspect-[343/228]',
+  aspectClassName = 'aspect-[304/228]',
   showDots = true,
   onRemove,
 }: Props) {
@@ -101,13 +101,12 @@ export default function ImageCarousel({
       <div
         className={[
           'relative overflow-hidden rounded-2xl bg-gray-100',
-          aspectClassName,
         ].join(' ')}
       >
         <div
           ref={scrollerRef}
           className={[
-            'h-full w-full flex overflow-x-auto',
+            'w-full flex overflow-x-auto',
             'snap-x snap-mandatory',
             'scrollbar-hide',
             canSlide ? 'cursor-grab active:cursor-grabbing' : '',
@@ -120,8 +119,9 @@ export default function ImageCarousel({
           {images.map((src, idx) => (
             <div
               key={`${src}-${idx}`}
-              className="relative h-full w-full flex-none snap-center"
+              className="relative w-full flex-none snap-center"
             >
+
             {brokenImages.has(idx) ? (
                 <div className="h-full w-full bg-gray-100 flex items-center justify-center">
                   <span className="text-xs text-gray-400">이미지를 불러올 수 없습니다</span>
@@ -130,7 +130,9 @@ export default function ImageCarousel({
                 <img
                   src={src}
                   alt=""
-                  className="h-full w-full object-cover"
+                  className={`h-full w-full object-cover ${
+                    aspectClassName
+                  }`}
                   loading="lazy"
                   decoding="async"
                   draggable={false}

--- a/src/shared/components/PostCard.tsx
+++ b/src/shared/components/PostCard.tsx
@@ -5,6 +5,7 @@ import { API_BASE_URL, ROUTES } from '@shared/constants';
 import BottomSheet from '@shared/components/BottomSheet';
 import Modal from '@shared/components/Modal';
 import { deletePost, reportPost, postLike, deleteLike } from '@features/post/api';
+import ImageCarousel from './ImageCarousel';
 
 interface PostCardProps {
   post: any;
@@ -22,16 +23,16 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
   const author = post?.author;
   const content = post?.content;
 
-  const imageList = post?.image
-    ? post.image.split(',')
-        .map((img: string) => img.trim())
-        .filter((img: string) => {
-          if (!img) return false;
-          if (img === 'undefined' || img === 'null') return false;
-          if (img === API_BASE_URL || img === `${API_BASE_URL}/`) return false;
-          return true;
-        })
-    : [];
+const imageList = post?.image
+  ? post.image.split(',')
+      .map((img: string) => img.trim())
+      .filter((img: string) => {
+        if (!img || img === 'undefined' || img === 'null') return false;
+        const isOnlyBaseUrl = img === API_BASE_URL || img === `${API_BASE_URL}/`;
+        const hasExtension = img.includes('.');
+        return !isOnlyBaseUrl && hasExtension;
+      })
+  : [];
 
   const getImageUrl = (img: string) => {
     if (!img) return `${API_BASE_URL}/1687141187512.png`;
@@ -136,24 +137,17 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
             {content}
           </p>
 
-          {/* 이미지 */}
-          {imageList.length > 0 && (
-            <div className="w-[304px] h-[228px] rounded-[10px] overflow-hidden border border-[#DBDBDB] mb-3 relative bg-gray-50">
-              <img
-                src={getImageUrl(imageList[0])}
-                alt="게시글 이미지"
-                className="w-full object-cover"
-                onError={(e) => {
-                  (e.currentTarget.parentElement as HTMLElement).style.display = 'none';
-                }}
-              />
-              {imageList.length > 1 && (
-                <div className="absolute top-2 right-2 bg-black/50 text-white text-[10px] px-2 py-1 rounded-full">
-                  +{imageList.length - 1}
-                </div>
-              )}
-            </div>
-          )}
+          {/* 이미지 영역 - ImageCarousel로 교체 */}
+{imageList.length > 0 && (
+  <div className="w-full mb-3 overflow-hidden rounded-[10px] border border-[#DBDBDB]">
+    <ImageCarousel
+      images={imageList.map((img) => getImageUrl(img))} 
+      className='w-full h-full object-cover'
+      // aspectClassName = 'h-[228px]'
+      showDots={imageList.length > 1}
+    /> 
+  </div>
+)}
 
           {/* 좋아요 · 댓글 */}
           <div className="flex gap-4 items-center">


### PR DESCRIPTION
## 🍊 작업 요약
게시글 카드(`PostCard`)와 캐러셀(`ImageCarousel`)에서 발생하던 이미지 노출 및 정렬 오류를 통합적으로 해결

## ✨ 변경 사항
 **레이아웃 유연화**: 고정 수치 대신 `w-full`과 `object-cover`를 조합하여 기기 너비에 상관없이 이미지가 꽉 차고 정렬이 어긋나지 않도록 수정

Closes #2