### PR TITLE
[perf] 이미지 로딩 스피너 추가 및 lazy loading 적용 (#165)

### DIFF
--- a/src/shared/components/ImageCarousel.tsx
+++ b/src/shared/components/ImageCarousel.tsx
@@ -21,6 +21,15 @@ export default function ImageCarousel({
   const scrollerRef = useRef<HTMLDivElement>(null)
   const [active, setActive] = useState(0)
   const [brokenImages, setBrokenImages] = useState<Set<number>>(new Set())
+  const [loadedImages, setLoadedImages] = useState<Set<number>>(new Set())
+
+const handleImageLoad = (idx: number) => {
+  setLoadedImages((prev) => {
+    const next = new Set(prev)
+    next.add(idx)
+    return next
+  })
+}
 
   const handleImageError = (idx: number) => {
     setBrokenImages((prev) => {
@@ -119,16 +128,24 @@ export default function ImageCarousel({
                   <span className="text-xs text-gray-400">이미지를 불러올 수 없습니다</span>
                 </div>
               ) : (
-                <img
-                  src={src}
-                  alt={`${idx + 1}번째 게시글 이미지 (총 ${count}개)`}
-                  className="h-full w-full object-cover"
-                  loading="lazy"
-                  decoding="async"
-                  draggable={false}
-                  onError={() => handleImageError(idx)}
-                />
-              )}
+  <>
+    {!loadedImages.has(idx) && !brokenImages.has(idx) && (
+      <div className="absolute inset-0 flex items-center justify-center bg-gray-100">
+        <div className="w-6 h-6 border-2 border-gray-300 border-t-[#F28C45] rounded-full animate-spin" />
+      </div>
+    )}
+    <img
+      src={src}
+      alt={`${idx + 1}번째 게시글 이미지 (총 ${count}개)`}
+      className="h-full w-full object-cover"
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+      onLoad={() => handleImageLoad(idx)}
+      onError={() => handleImageError(idx)}
+    />
+  </>
+)}
 
               {onRemove && (
                 <button

--- a/src/shared/components/PostCard.tsx
+++ b/src/shared/components/PostCard.tsx
@@ -95,6 +95,7 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
           src={resolveImageUrl(author.image) ?? DEFAULT_AUTHOR_IMAGE}
           alt={`${author.username}님의 프로필`}
           className="w-[42px] h-[42px] rounded-full object-cover bg-gray-100 flex-shrink-0"
+          loading="lazy"
           onError={(e) => { (e.target as HTMLImageElement).src = DEFAULT_AUTHOR_IMAGE }}
         />
 


### PR DESCRIPTION
작업 요약: 홈 피드 이미지 로딩 UX 개선
변경 사항:
- ImageCarousel 이미지 로딩 중 스피너 추가
- PostCard 프로필 이미지 lazy loading 적용
테스트 방법: 크롬 개발자 도구 Network 탭에서 Slow 3G 설정 후 홈 피드 확인
관련 이슈: Closes #165