### PR TITLE
[perf] 이미지 로딩 최적화 및 PC UX 개선 (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ SNS의 소통 구조와 상품 홍보 기능을 하나의 플랫폼에서 제공
 
 | ID | PW |
 |----|----|
-| kindpeople22@sample.com | 242455 |
+| tmilover@sample.com | 555555 |
 
 <br>
 

--- a/src/features/join/pages/JoinProfilePage.tsx
+++ b/src/features/join/pages/JoinProfilePage.tsx
@@ -5,7 +5,7 @@ import Button from '@shared/components/Button'
 import Input from '@shared/components/Input'
 import { ROUTES } from '@shared/constants'
 import { useAuth } from '@app/providers/AuthProvider'
-import { validateUsername, validateAccountName, isNetworkError } from '@shared/utils'
+import { validateUsername, validateAccountName, isNetworkError, resizeImage } from '@shared/utils'
 import { checkAccountName, signup } from '../api'
 import { uploadImage } from '@shared/api/client'
 import { User } from '@shared/types'
@@ -45,15 +45,16 @@ export default function JoinProfilePage() {
     }
   }, [email, password, navigate])
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const file = e.target.files?.[0]
+  if (!file) return
 
-    setImageFile(file)
-    setImagePreview(URL.createObjectURL(file))
-    setImageError('')
-    e.target.value = ''
-  }
+  const resized = await resizeImage(file)
+  setImageFile(resized)
+  setImagePreview(URL.createObjectURL(resized))
+  setImageError('')
+  e.target.value = ''
+}
   const handleResetImage = () => {
     setImageFile(null)
     setImagePreview(DEFAULT_AVATAR)

--- a/src/features/profile/pages/ProfileEditPage.tsx
+++ b/src/features/profile/pages/ProfileEditPage.tsx
@@ -4,7 +4,7 @@ import TopBar from '@app/layouts/TopBar'
 import Button from '@shared/components/Button'
 import Input from '@shared/components/Input'
 import { useAuth } from '@app/providers/AuthProvider'
-import { validateUsername, validateAccountName } from '@shared/utils'
+import { validateUsername, validateAccountName, resizeImage } from '@shared/utils'
 import { checkAccountName, updateMyProfile } from '../api'
 import { uploadImage } from '@shared/api/client'
 import { usePageTitle } from '@shared/hooks/usePageTitle'
@@ -33,12 +33,13 @@ export default function ProfileEditPage() {
 
   const isValid = !usernameError && !accountnameError && username !== '' && accountname !== ''
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    setImageFile(file)
-    setImagePreview(URL.createObjectURL(file))
-  }
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const file = e.target.files?.[0]
+  if (!file) return
+  const resized = await resizeImage(file)
+  setImageFile(resized)
+  setImagePreview(URL.createObjectURL(resized))
+}
 
   const handleAccountnameBlur = async () => {
     const localErr = validateAccountName(accountname)

--- a/src/features/upload/pages/PostWritePage.tsx
+++ b/src/features/upload/pages/PostWritePage.tsx
@@ -9,7 +9,7 @@ import { buildPostPrompt } from '@shared/prompts'
 import { useKeyboardHeight } from '@shared/hooks/useKeyboardHeight'
 import { createPost, updatePost } from '../api'
 import { getPostDetail } from '@features/post/api'
-import { parsePostImages } from '@shared/utils'
+import { parsePostImages, resizeImage } from '@shared/utils'
 import ImageCarousel from '@shared/components/ImageCarousel'
 import TopBar from '@app/layouts/TopBar'
 import { usePageTitle } from '@shared/hooks/usePageTitle'
@@ -88,9 +88,10 @@ export default function PostWritePage() {
     try {
       const newImages = await Promise.all(
         toAdd.map(async (file) => {
-          const url = await uploadImage(file)
-          return { file, preview: URL.createObjectURL(file), url }
-        }),
+  const resized = await resizeImage(file)
+  const url = await uploadImage(resized)
+  return { file: resized, preview: URL.createObjectURL(resized), url }
+}),
       )
       setImages((prev) => [...prev, ...newImages])
     } catch {

--- a/src/shared/components/Avatar.tsx
+++ b/src/shared/components/Avatar.tsx
@@ -25,6 +25,7 @@ export default function Avatar({ src, alt = '', size = 'md', className = '' }: A
     <img
       src={resolvedSrc}
       alt={alt}
+      decoding="async"
       onError={(e) => {
         ;(e.target as HTMLImageElement).src = defaultAvatar
       }}

--- a/src/shared/components/ImageCarousel.tsx
+++ b/src/shared/components/ImageCarousel.tsx
@@ -150,7 +150,8 @@ const handleImageLoad = (idx: number) => {
               {onRemove && (
                 <button
                   type="button"
-                  onClick={() => onRemove(idx)}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={(e) => { e.stopPropagation(); onRemove(idx) }}
                   aria-label={`이미지 ${idx + 1} 삭제`}
                   className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-full bg-black/35 text-white"
                 >

--- a/src/shared/components/PostCard.tsx
+++ b/src/shared/components/PostCard.tsx
@@ -22,6 +22,7 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
   const navigate = useNavigate()
   const [isLiked, setIsLiked] = useState(post.hearted)
   const [heartCount, setHeartCount] = useState(post.heartCount)
+  const [moved, setMoved] = useState(false)
   const sheet = useBottomSheet()
   const deleteModal = useModal()
 
@@ -84,7 +85,9 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
   return (
     <>
       <article
-        onClick={() => navigate(ROUTES.POST_DETAIL(post.id))}
+        onMouseDown={() => setMoved(false)}
+        onMouseMove={() => setMoved(true)}
+        onClick={() => { if (!moved) navigate(ROUTES.POST_DETAIL(post.id)) }}
         className="w-full py-4 flex gap-3 border-b border-[#DBDBDB] last:border-none cursor-pointer px-4"
       >
         <img
@@ -96,6 +99,7 @@ export default function PostCard({ post, isMyPost = false, onDelete }: PostCardP
           alt={`${author.username}님의 프로필`}
           className="w-[42px] h-[42px] rounded-full object-cover bg-gray-100 flex-shrink-0"
           loading="lazy"
+          decoding="async"
           onError={(e) => { (e.target as HTMLImageElement).src = DEFAULT_AUTHOR_IMAGE }}
         />
 

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -107,3 +107,34 @@ export function parsePostImages(image: string): string[] {
     .map((url) => resolveImageUrl(url))
     .filter((url): url is string => !!url)
 }
+
+/** 이미지 리사이징 (최대 1024px) */
+export const resizeImage = (file: File, maxSize = 1024): Promise<File> => {
+  return new Promise((resolve) => {
+    const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl)
+      const { width, height } = img
+      if (width <= maxSize && height <= maxSize) {
+        resolve(file)
+        return
+      }
+      const ratio = Math.min(maxSize / width, maxSize / height)
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.round(width * ratio)
+      canvas.height = Math.round(height * ratio)
+      const ctx = canvas.getContext('2d')!
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height)
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) { resolve(file); return }
+          resolve(new File([blob], file.name, { type: 'image/jpeg' }))
+        },
+        'image/jpeg',
+        0.85,
+      )
+    }
+    img.src = objectUrl
+  })
+}


### PR DESCRIPTION
작업 요약: 이미지 로딩 최적화 및 PC 드래그/클릭 UX 개선

변경 사항:
- ImageCarousel 스피너 추가 및 X 버튼 PC 클릭 문제 해결
- PostCard 드래그/클릭 구분 처리
- 이미지 업로드 시 1024px 자동 리사이징 적용
- 테스트계정 변경

테스트 방법:
- 홈피드에서 이미지 드래그 후 상세페이지 이동 안 되는지 확인
- 게시글 작성 이미지 2개 이상에서 X 버튼 동작 확인
- 새 이미지 업로드 후 Network 탭에서 용량 확인

관련 이슈: Closes #165